### PR TITLE
Feat: Message엔티티를 상속하는 2개의 클래스 추가

### DIFF
--- a/src/main/java/com/capstone/smutaxi/dto/MessageDto.java
+++ b/src/main/java/com/capstone/smutaxi/dto/MessageDto.java
@@ -16,4 +16,5 @@ public class MessageDto {
     private String senderProfileImageUrl;
     @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime sentTime;
+    private Boolean isSystem;
 }

--- a/src/main/java/com/capstone/smutaxi/entity/Message.java
+++ b/src/main/java/com/capstone/smutaxi/entity/Message.java
@@ -4,6 +4,7 @@ package com.capstone.smutaxi.entity;
 import com.capstone.smutaxi.dto.MessageDto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 
@@ -14,6 +15,9 @@ import static javax.persistence.FetchType.*;
 
 @Entity
 @Getter
+@Setter
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "message_type")
 @Table(name = "messages")
 public class Message {
 
@@ -22,16 +26,12 @@ public class Message {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String senderEmail;
-
-    private String senderName;
-
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime sendTime;
 
     private String message;
 
-    private String senderProfileImageUrl;
+    private String senderName;
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
@@ -39,9 +39,7 @@ public class Message {
     public MessageDto toMessageDto() {
         MessageDto messageDto = new MessageDto();
         messageDto.setMessageId(this.id);
-        messageDto.setSenderId(this.senderEmail);
         messageDto.setSenderName(this.senderName);
-        messageDto.setSenderProfileImageUrl(this.senderProfileImageUrl);
         messageDto.setMessage(this.message);
         messageDto.setSentTime(this.sendTime);
         return messageDto;

--- a/src/main/java/com/capstone/smutaxi/entity/SystemMessage.java
+++ b/src/main/java/com/capstone/smutaxi/entity/SystemMessage.java
@@ -1,0 +1,22 @@
+package com.capstone.smutaxi.entity;
+
+import com.capstone.smutaxi.dto.MessageDto;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("S")
+@Getter @Setter
+public class SystemMessage extends Message{
+    private Boolean isSystem;
+
+    @Override
+    public MessageDto toMessageDto() {
+        MessageDto messageDto = super.toMessageDto();
+        messageDto.setIsSystem(this.isSystem);
+        return messageDto;
+    }
+}

--- a/src/main/java/com/capstone/smutaxi/entity/UserMessage.java
+++ b/src/main/java/com/capstone/smutaxi/entity/UserMessage.java
@@ -1,0 +1,24 @@
+package com.capstone.smutaxi.entity;
+
+import com.capstone.smutaxi.dto.MessageDto;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("U")
+@Getter @Setter
+public class UserMessage extends Message{
+    private String senderEmail;
+    private String senderProfileImageUrl;
+
+    @Override
+    public MessageDto toMessageDto() {
+        MessageDto messageDto = super.toMessageDto();
+        messageDto.setSenderId(this.senderEmail);
+        messageDto.setSenderProfileImageUrl(this.senderProfileImageUrl);
+        return messageDto;
+    }
+}


### PR DESCRIPTION
프론트엔드 issue #14의 메세지쪽을 참고해주세요.

1. Message엔티티를 상속하는 SystemMessage와 UserMessage 추가
2. /pub/exit 추가

ws://localhost:8080/ws/websocket     연결

/sub/channel/1      구독

/pub/send         발행

필요 유저 메세지 형식
{
  "senderEmail": "1",
  "senderName": "John Doe",
  "senderProfileImageUrl": "null",
  "sendTime":"2023-08-03T06:01",
  "message": "hi phone!",
  "chatRoom": {
    "id": 1
  }
}

/pub/exit     채팅방 나감(시스템메세지 삽입)

필요 형식
{
  "senderName": "John Doe",
  "sendTime":"2023-08-03T06:01",
  "chatRoom": {
    "id": 1
  }
}